### PR TITLE
Records tracked event in configmap

### DIFF
--- a/pkg/eventstores/idempotent/store.go
+++ b/pkg/eventstores/idempotent/store.go
@@ -1,61 +1,247 @@
 package idempotent
 
 import (
+	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/loft-sh/magpie/types"
+	errors2 "github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"k8s.io/apimachinery/pkg/util/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ types.EventStore[string] = (*Store)(nil)
+var _ types.EventStore = (*Store)(nil)
 
 const (
-	defaultSize      = 100
-	resourceIDFormat = "%s/%s/%s"
+	cmNameFormat = "magpie-%s-%s-%s"
 )
 
 type Store struct {
 	sync.RWMutex
-	cache *lru.Cache[types.ResourceKey, []types.Event]
+	client      client.Client
+	configMapNS string
+	gvk         schema.GroupVersionKind
 }
 
-func NewStore() (*Store, error) {
-	cache, err := lru.New[types.ResourceKey, []types.Event](defaultSize)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize cache: %w", err)
-	}
-	return &Store{cache: cache}, nil
+func NewStore(ns string, gvk schema.GroupVersionKind, client client.Client) (*Store, error) {
+	return &Store{configMapNS: ns, gvk: gvk, client: client}, nil
 }
 
-func (e *Store) List(key types.ResourceKey) []types.Event {
+func (e *Store) List(ctx context.Context, key types.ResourceKey) ([]types.Event, error) {
 	e.RLock()
 	defer e.RUnlock()
 
-	v, _ := e.cache.Get(key)
-	return v
+	cm, err := e.getGVKConfigMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get configmap: %w", err)
+	}
+
+	events, err := e.listEventsFromConfigMap(cm, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list events: %w", err)
+	}
+
+	return events, nil
 }
 
-func (e *Store) Add(key types.ResourceKey, event types.Event) bool {
+func (e *Store) Add(ctx context.Context, eventsToAdd ...types.KeyedEvent) error {
+	if len(eventsToAdd) == 0 {
+		return nil
+	}
+
 	e.Lock()
 	defer e.Unlock()
 
-	event.Time = time.Now()
-	v, _ := e.cache.Get(key)
-	if v[len(v)-1].EventType == event.EventType {
+	eventTimestamp := time.Now()
+
+	cm, err := e.getGVKConfigMap(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get configmap: %w", err)
+	}
+
+	updated := false
+	for _, keyedEvent := range eventsToAdd {
+		currentEvents, err := e.listEventsFromConfigMap(cm, keyedEvent.Key)
+		if err != nil {
+			return fmt.Errorf("failed to list events: %w", err)
+		}
+		if currentEvents == nil {
+			currentEvents = make([]types.Event, 0, 1)
+		}
+
+		if len(currentEvents) > 0 && currentEvents[len(currentEvents)-1].EventType == keyedEvent.EventType {
+			continue
+		}
+
+		updated = true
+		keyedEvent.Time = eventTimestamp
+		currentEvents = append(currentEvents, keyedEvent.Event)
+
+		err = e.addEventsToConfigMap(cm, keyedEvent.Key, currentEvents)
+		if err != nil {
+			return fmt.Errorf("failed to add events to configmap: %w", err)
+		}
+	}
+
+	if updated {
+		err = e.client.Update(ctx, cm)
+		if err != nil {
+			return fmt.Errorf("failed to update configmap: %w", err)
+		}
+	}
+	return nil
+}
+
+func (e *Store) InitializeForGVK(ctx context.Context, ns string) error {
+	cm, err := e.getGVKConfigMap(ctx)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors2.Wrap(err, fmt.Sprintf("failed to get magpie ConfigMap [%s]", e.getCMName()))
+	}
+	if errors.IsNotFound(err) {
+		cm = &v1.ConfigMap{}
+		cm.Namespace = ns
+		cm.Name = e.getCMName()
+
+		err = e.client.Create(ctx, cm)
+		if err != nil {
+			return errors2.Wrap(err, "failed to create ConfigMap")
+		}
+	}
+
+	list := unstructured.UnstructuredList{Items: []unstructured.Unstructured{}}
+
+	list.SetGroupVersionKind(e.gvk)
+	err = e.client.List(ctx, &list, &client.ListOptions{})
+	if err != nil {
+		return errors2.Wrap(err, fmt.Sprintf("failed to list e.gvk [%s]", e.gvk.String()))
+	}
+
+	currentGVKids := make([]string, len(list.Items))
+	for index, item := range list.Items {
+		currentGVKids[index] = e.GetResourceKeyFromUnstructured(item).String()
+	}
+
+	eventsToAdd := make([]types.KeyedEvent, 0)
+	for keyString := range cm.Data {
+		if !slices.Contains(currentGVKids, keyString) {
+			key, err := e.parseResourceKeyFromString(keyString)
+			if err != nil {
+				return errors2.Wrapf(err, "failed to parse resource key [%s]", keyString)
+			}
+
+			eventsToAdd = append(eventsToAdd, types.KeyedEvent{Key: key, Event: types.Event{EventType: types.InferredDelete}})
+		}
+	}
+
+	for index, keyString := range currentGVKids {
+		updated := e.addObjToConfigMap(list.Items[index], cm)
+		key, err := e.parseResourceKeyFromString(keyString)
+		if err != nil {
+			return errors2.Wrapf(err, "failed to parse resource key [%s]", keyString)
+		}
+		if updated {
+			eventsToAdd = append(eventsToAdd, types.KeyedEvent{Key: key, Event: types.Event{Obj: list.Items[index].Object, EventType: types.InferredCreate}}) // TODO: make InferredCreate idempotent with create
+		}
+	}
+
+	if len(eventsToAdd) > 0 {
+		err = e.Add(ctx, eventsToAdd...)
+		if err != nil {
+			return errors2.Wrapf(err, "failed to add event to store")
+		}
+	}
+
+	return nil
+}
+
+func (e *Store) GetResourceKeyFromUnstructured(obj unstructured.Unstructured) types.ResourceKey {
+	return e.getResourceKey(obj.GetNamespace(), obj.GetName(), obj.GetUID())
+}
+
+func (e *Store) getResourceKey(ns, name string, uid ktypes.UID) types.ResourceKey {
+	return types.ResourceKey{
+		NamespacedName: ktypes.NamespacedName{
+			Namespace: ns,
+			Name:      name,
+		},
+		UID:              uid,
+		GroupVersionKind: e.gvk,
+	}
+}
+
+func (e *Store) addObjToConfigMap(obj unstructured.Unstructured, cm *v1.ConfigMap) bool {
+	if _, ok := cm.Data[e.GetResourceKeyFromUnstructured(obj).String()]; ok {
 		return false
 	}
-	v = append(v, event)
-	evicted := e.cache.Add(key, v)
-	if evicted {
-		log.Log.Info(fmt.Sprintf("eviction occured to make room for gvk [%s] events", key))
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
 	}
+	cm.Data[e.GetResourceKeyFromUnstructured(obj).String()] = obj.GetCreationTimestamp().String()
 	return true
 }
 
-func getResourceID(id ktypes.NamespacedName, uid string) string {
-	return fmt.Sprintf(resourceIDFormat, id.Namespace, id.Name, uid)
+func (e *Store) parseResourceKeyFromString(key string) (types.ResourceKey, error) {
+	parts := strings.Split(key, "_")
+	if len(parts) != 3 {
+		return types.ResourceKey{}, fmt.Errorf("invalid resource key string [%s], should be of format \"Namespace-Name-UID\"", key)
+	}
+	return types.ResourceKey{NamespacedName: ktypes.NamespacedName{Namespace: parts[0], Name: parts[1]}, UID: ktypes.UID(parts[2]), GroupVersionKind: e.gvk}, nil
+}
+
+func (e *Store) getGVKConfigMap(ctx context.Context) (*v1.ConfigMap, error) {
+	cm := &v1.ConfigMap{}
+	err := e.client.Get(ctx, ktypes.NamespacedName{Name: e.getCMName(), Namespace: e.configMapNS}, cm)
+	if err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+func (e *Store) getCMName() string {
+	cmName := strings.ToLower(fmt.Sprintf(cmNameFormat, e.gvk.Group, e.gvk.Version, e.gvk.Kind))
+	if e.gvk.Group == "" {
+		cmName = strings.ToLower(fmt.Sprintf("%s-%s", e.gvk.Kind, e.gvk.Version))
+	}
+	return strings.ToLower(cmName)
+}
+
+func (e *Store) listEventsFromConfigMap(cm *v1.ConfigMap, key types.ResourceKey) ([]types.Event, error) {
+	if cm.Data == nil {
+		return nil, nil
+	}
+
+	v, ok := cm.Data[key.String()]
+	if !ok {
+		return nil, nil
+	}
+
+	var events []types.Event
+	if err := json.Unmarshal([]byte(v), &events); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal events: %w", err)
+	}
+	return events, nil
+}
+
+func (e *Store) addEventsToConfigMap(cm *v1.ConfigMap, key types.ResourceKey, events []types.Event) error {
+	eventsJSON, err := json.Marshal(events)
+	if err != nil {
+		return fmt.Errorf("failed to marshal events: %w", err)
+	}
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string, 1)
+	}
+
+	cm.Data[key.String()] = string(eventsJSON)
+	return nil
 }

--- a/pkg/recorder/reconciler.go
+++ b/pkg/recorder/reconciler.go
@@ -3,44 +3,34 @@ package recorder
 import (
 	"context"
 	"fmt"
-	"slices"
-	"time"
+	"strings"
 
 	"github.com/loft-sh/magpie/pkg/eventstores/idempotent"
 	"github.com/loft-sh/magpie/types"
 	errors2 "github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	cmNameFormat = "magpie-%s-%s-%s"
-)
-
 var _ reconcile.TypedReconciler[ctrl.Request]
 
 type Target struct {
-	GVK     schema.GroupVersionKind
-	Fields  [][]string
-	updates bool
-	creates bool
-	deletes bool
-
-	memory map[string]struct{}
+	GVK         schema.GroupVersionKind
+	Fields      [][]string
+	TrackCreate bool
+	TrackDelete bool
 }
 
 type Reconciler struct {
 	Client      client.Client
 	configMapNS string
 	target      Target
-	store       types.EventStore[string]
+	store       types.EventStore
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
@@ -49,7 +39,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	err := r.Client.Get(ctx, client.ObjectKey{Name: request.Name, Namespace: request.Namespace}, &obj)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			err = r.SyncTargetDelete(ctx, obj)
+			err = r.SyncTargetDelete(ctx, r.store.GetResourceKeyFromUnstructured(obj))
 			if err != nil {
 				return reconcile.Result{}, errors2.Wrap(err, "failed to sync delete event")
 			}
@@ -57,52 +47,47 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	err = r.SyncTargetAdd(ctx, obj)
+	err = r.SyncTargetCreate(ctx, obj)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	fmt.Print(r.store.List(getResourceIDFromUnstructured(obj)))
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) SyncTargetAdd(ctx context.Context, obj unstructured.Unstructured) error {
-	cm, err := r.getGVKConfigMap(ctx, r.target.GVK)
-	if err != nil {
-		return errors2.Wrapf(err, "get configmap for gvk [%s]", r.target.GVK.String())
-	}
-
-	if _, ok := cm.Data[getResourceIDFromUnstructured(obj)]; ok {
+func (r *Reconciler) SyncTargetCreate(ctx context.Context, obj unstructured.Unstructured) error {
+	if !r.target.TrackCreate {
 		return nil
 	}
 
-	cm.Data[getResourceIDFromUnstructured(obj)] = obj.GetCreationTimestamp().String()
-
-	err = r.Client.Update(ctx, cm)
+	err := r.store.Add(
+		ctx,
+		types.KeyedEvent{
+			Key: types.ResourceKey{
+				NamespacedName: ktypes.NamespacedName{
+					Namespace: obj.GetNamespace(),
+					Name:      obj.GetName()},
+				UID:              obj.GetUID(),
+				GroupVersionKind: r.target.GVK},
+			Event: types.Event{Obj: r.createEventFromTarget(obj.Object), EventType: types.Create},
+		})
 	if err != nil {
-		return errors2.Wrapf(err, "update configmap for gvk [%s]", r.target.GVK.String())
+		return fmt.Errorf("failed to add event to store: %w", err)
 	}
 
-	r.store.Add(getResourceIDFromUnstructured(obj), types.Event{Obj: obj.Object, EventType: types.Create})
 	return nil
 }
 
-func (r *Reconciler) SyncTargetDelete(ctx context.Context, key string) error {
-	cm, err := r.getGVKConfigMap(ctx, r.target.GVK)
-	if err != nil {
-		return errors2.Wrapf(err, "get configmap for gvk [%s]", r.target.GVK.String())
-	}
-
-	if _, ok := cm.Data[key]; !ok {
+func (r *Reconciler) SyncTargetDelete(ctx context.Context, key types.ResourceKey) error {
+	if !r.target.TrackDelete {
 		return nil
 	}
-	delete(cm.Data, key)
-	err = r.Client.Update(ctx, cm)
+
+	err := r.store.Add(ctx, types.KeyedEvent{Key: key, Event: types.Event{EventType: types.Delete}})
 	if err != nil {
-		return errors2.Wrapf(err, "update configmap for gvk [%s]", r.target.GVK.String())
+		return errors2.Wrapf(err, "failed to add event to store")
 	}
 
-	r.store.Add(key, types.Event{EventType: types.Delete})
 	return nil
 }
 
@@ -116,16 +101,21 @@ func (r *Reconciler) createEventFromTarget(obj map[string]interface{}) map[strin
 }
 
 func SetupWithManagerForTargets(ctx context.Context, mgr ctrl.Manager, targets []Target, cmNS string) error {
-	eventStore, err := idempotent.NewStore()
-	if err != nil {
-		return errors2.Wrap(err, "failed to create event store")
-	}
-
 	for _, target := range targets {
+		eventStore, err := idempotent.NewStore(cmNS, target.GVK, mgr.GetClient())
+		if err != nil {
+			return errors2.Wrap(err, "failed to create event store")
+		}
+
 		r := &Reconciler{
-			Client: mgr.GetClient(),
-			target: target,
-			store:  eventStore,
+			Client:      mgr.GetClient(),
+			target:      target,
+			store:       eventStore,
+			configMapNS: cmNS,
+		}
+		err = eventStore.InitializeForGVK(ctx, cmNS)
+		if err != nil {
+			return errors2.Wrapf(err, "failed to initialize event store for gvk [%s]", target.GVK.String())
 		}
 
 		err = ctrl.NewControllerManagedBy(mgr).
@@ -136,91 +126,18 @@ func SetupWithManagerForTargets(ctx context.Context, mgr ctrl.Manager, targets [
 		if err != nil {
 			return err
 		}
-
-		go func() {
-			mgr.GetCache().WaitForCacheSync(ctx)
-
-			err = r.ensureConfigMap(ctx, mgr, target.GVK, cmNS)
-			if err != nil {
-				klog.V(1).ErrorS(err, fmt.Sprintf("failed to list ConfigMaps for gvr [%s]", target.GVK))
-				<-ctx.Done()
-				return
-			}
-
-		}()
 	}
 	return nil
 }
 
-func (r *Reconciler) ensureConfigMap(ctx context.Context, mgr ctrl.Manager, gvk schema.GroupVersionKind, ns string) error {
-	cmName := fmt.Sprintf(cmNameFormat, gvk.Group, gvk.Version, gvk.Kind)
-	cm, err := r.getGVKConfigMap(ctx, gvk)
-	if err != nil && !errors.IsNotFound(err) {
-		return errors2.Wrap(err, fmt.Sprintf("failed to get magpie ConfigMap [%s]", cmName))
+func (r *Reconciler) parseResourceKeyFromString(key string) (types.ResourceKey, error) {
+	parts := strings.Split(key, "_")
+	if len(parts) != 3 {
+		return types.ResourceKey{}, fmt.Errorf("invalid resource key string [%s], should be of format \"Namespace-Name-UID\"", key)
 	}
-	if errors.IsNotFound(err) {
-		cm.Namespace = ns
-		err = mgr.GetClient().Create(ctx, cm)
-		if err != nil {
-			return errors2.Wrap(err, "failed to create ConfigMap")
-		}
-	}
-
-	list := unstructured.UnstructuredList{Items: []unstructured.Unstructured{}}
-
-	list.SetGroupVersionKind(gvk)
-	err = mgr.GetClient().List(ctx, &list, nil)
-	if err != nil {
-		return errors2.Wrap(err, fmt.Sprintf("failed to list gvk [%s]", gvk.String()))
-	}
-
-	currentGVKids := make([]string, len(list.Items))
-	for index, item := range list.Items {
-		currentGVKids[index] = getResourceIDFromUnstructured(item)
-	}
-
-	cmNeedsUpdate := false
-	for key := range cm.Data {
-		if !slices.Contains(currentGVKids, key) {
-			cmNeedsUpdate = true
-			r.store.Add(key, types.Event{EventType: types.InferredDelete})
-			delete(cm.Data, key)
-		}
-	}
-	for index, key := range currentGVKids {
-		_, ok := cm.Data[key]
-		if ok {
-			continue
-		}
-		cmNeedsUpdate = true
-		cm.Data[key] = time.Now().String()
-		r.store.Add(key, types.Event{Obj: list.Items[index].Object, EventType: types.InferredCreate})
-	}
-	if cmNeedsUpdate {
-		err = mgr.GetClient().Update(ctx, cm)
-		if err != nil {
-			return errors2.Wrap(err, "failed to update ")
-		}
-	}
-	return nil
+	return types.ResourceKey{NamespacedName: ktypes.NamespacedName{Namespace: parts[0], Name: parts[1]}, UID: ktypes.UID(parts[2]), GroupVersionKind: r.target.GVK}, nil
 }
 
-func (r *Reconciler) getGVKConfigMap(ctx context.Context, gvk schema.GroupVersionKind) (*v1.ConfigMap, error) {
-	cm := &v1.ConfigMap{}
-	cmName := fmt.Sprintf(cmNameFormat, gvk.Group, gvk.Version, gvk.Kind)
-	err := r.Client.Get(ctx, ktypes.NamespacedName{Name: cmName, Namespace: r.configMapNS}, cm)
-	if err != nil {
-		return nil, err
-	}
-	return cm, nil
-}
-
-func getResourceID(ns, name, uid string) string {
-	return fmt.Sprintf(resourceIDFormat, ns, name, uid)
-}
-func getResourceIDFromUnstructured(obj unstructured.Unstructured) string {
-	return getResourceID(obj.GetNamespace(), obj.GetName(), string(obj.GetUID()))
-}
 func setNested(obj map[string]interface{}, val any, keys ...string) {
 	if obj == nil || len(keys) == 0 {
 		return

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -1,6 +1,13 @@
 package types
 
-type EventStore[key any] interface {
-	List(ResourceKey) []Event
-	Add(ResourceKey, Event) bool
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type EventStore interface {
+	List(ctx context.Context, key ResourceKey) ([]Event, error)
+	Add(ctx context.Context, event ...KeyedEvent) error
+	GetResourceKeyFromUnstructured(obj unstructured.Unstructured) ResourceKey
 }

--- a/types/type.go
+++ b/types/type.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"time"
@@ -16,12 +17,25 @@ const (
 type eventType int
 
 type Event struct {
-	Obj       map[string]interface{}
-	EventType eventType
-	Time      time.Time
+	Obj       map[string]interface{} `json:"obj,omitempty"`
+	EventType eventType              `json:"event_type,omitempty"`
+	Time      time.Time              `json:"time,omitempty"`
+}
+
+type KeyedEvent struct {
+	Event
+	Key ResourceKey
 }
 
 type ResourceKey struct {
 	types.NamespacedName
+	UID types.UID
 	schema.GroupVersionKind
+}
+
+func (r ResourceKey) String() string {
+	if r.Namespace == "" {
+		return fmt.Sprintf("%s_%s", r.Name, r.UID)
+	}
+	return fmt.Sprintf("%s_%s_%s", r.Namespace, r.Name, r.UID)
 }


### PR DESCRIPTION
Changed store to be entirely backed by a v1.ConfigMap. Using an in memory store can lead to missing events in the case that the parent process restarts before the events are sent.